### PR TITLE
Fix for error: Cannot find module ‘./device-config-schema’

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "wemo.coffee",
     "README.md",
-    "wemo-config-schema.coffee"
+    "wemo-config-schema.coffee",
+    "device-config-schema.coffee"
   ],
   "version": "0.0.2",
   "homepage": "https://github.com/muldy/pimatic-plugin-wemo",


### PR DESCRIPTION
Added missing file "device-config-schema.coffee" to "files" property of the package descriptor as reported in https://forum.pimatic.org/topic/2205/add-wemo-switch-device
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/muldy/pimatic-wemo/pull/1?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/muldy/pimatic-wemo/pull/1'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
